### PR TITLE
Issues/0001 interrupt level not configured

### DIFF
--- a/nRF5_SDK_11.0.0_89a8197/examples/ble_peripheral/ble_app_uart.ESB_Timeslot/custom/esb_timeslot.c
+++ b/nRF5_SDK_11.0.0_89a8197/examples/ble_peripheral/ble_app_uart.ESB_Timeslot/custom/esb_timeslot.c
@@ -457,15 +457,15 @@ uint32_t esb_timeslot_init(ut_data_handler_t evt_handler)
     // These can be any available IRQ as we're not using any of the hardware,
     // simply triggering them through software
     NVIC_ClearPendingIRQ(TIMESLOT_END_IRQn);
-    NVIC_SetPriority(TIMESLOT_END_IRQn, 1);
+    NVIC_SetPriority(TIMESLOT_END_IRQn, TIMESLOT_END_IRQPriority);
     NVIC_EnableIRQ(TIMESLOT_END_IRQn);
 
     NVIC_ClearPendingIRQ(TIMESLOT_BEGIN_IRQn);
-    NVIC_SetPriority(TIMESLOT_BEGIN_IRQn, 1);
+    NVIC_SetPriority(TIMESLOT_BEGIN_IRQn, TIMESLOT_BEGIN_IRQPriority);
     NVIC_EnableIRQ(TIMESLOT_BEGIN_IRQn);
 
     NVIC_ClearPendingIRQ(UESB_RX_HANDLE_IRQn);
-    NVIC_SetPriority(UESB_RX_HANDLE_IRQn, 1);
+    NVIC_SetPriority(UESB_RX_HANDLE_IRQn, UESB_RX_HANDLE_IRQPriority);
     NVIC_EnableIRQ(UESB_RX_HANDLE_IRQn);
 
 #if ESB_TIMESLOT_DEBUG_ENABLE

--- a/nRF5_SDK_11.0.0_89a8197/examples/ble_peripheral/ble_app_uart.ESB_Timeslot/custom/esb_timeslot.c
+++ b/nRF5_SDK_11.0.0_89a8197/examples/ble_peripheral/ble_app_uart.ESB_Timeslot/custom/esb_timeslot.c
@@ -22,7 +22,7 @@
 
 #define UESB_RX_HANDLE_IRQn         WDT_IRQn                /**< Re-used WDT interrupt for processing the RX data from UESB. */
 #define UESB_RX_HANDLE_IRQHandler   WDT_IRQHandler          /**< The IRQ handler of WDT interrupt */
-#define UESB_RX_HANDLE_IRQPriority  3                       /**< Interrupt priority of @ref UESB_RX_HANDLE_IRQn. */
+#define UESB_RX_HANDLE_IRQPriority  1                       /**< Interrupt priority of @ref UESB_RX_HANDLE_IRQn. */
 
 #define MAX_TX_ATTEMPTS             10                      /**< Maximum attempt before discarding the packet (the number of trial = MAX_TX_ATTEMPTS x retransmit_count, if timeslot is large enough) */
 #define TS_LEN_US                   (5000UL)                /**< Length of timeslot to be requested. */


### PR DESCRIPTION
The values configured in TIMESLOT_BEGIN_IRQPriority, TIMESLOT_END_IRQPriority and UESB_RX_HANDLE_IRQPriority have not been used before. They are now applied during the initialization phase.

The esb_timeslot is designed so that the three priorities should be the same because the underlying nrf_esb library does not handle mutual exclusion.